### PR TITLE
P0.2 + P2.9: Fix CSV require, add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
     env:
       RAILS_ENV: test
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/vaalitulostin_test
+      # The integration specs shell out to the psql CLI (\COPY seed import),
+      # which connects via these instead of DATABASE_URL.
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: postgres
       SECRET_KEY_BASE: ci-only-not-a-secret
       SITE_ADDRESS: https://vaalitulostin.test
       EMAIL_FROM_ADDRESS: vaalit@hyy.fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/vaalitulostin_test
+      SECRET_KEY_BASE: ci-only-not-a-secret
+      SITE_ADDRESS: https://vaalitulostin.test
+      EMAIL_FROM_ADDRESS: vaalit@hyy.fi
+      EMAIL_FROM_NAME: HYY vaalipalvelut
+      AWS_S3_BASE_URL: s3.amazonaws.com
+      AWS_S3_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_S3_BUCKET_NAME: vaalitulostin-test
+      RESULT_ADDRESS: https://s3.amazonaws.com/vaalitulostin-test
+      TZ: Europe/Helsinki
+      VOTING_API_BASE_URL: http://localhost:3000
+      VOTING_API_SESSION_LINK_ENDPOINT: /api/sessions/link
+      VOTING_API_VOTERS_ENDPOINT: /api/elections/1/voters
+      VOTING_API_VOTES_ENDPOINT: /api/export/elections/1/votes
+      VOTING_API_SUMMARY_ENDPOINT: /api/export/elections/1/summary
+      VOTING_API_JWT_APIKEY: ci-only-not-a-secret
+      ROLLBAR_ENV: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec rake db:create db:schema:load
+      - run: bundle exec rspec
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: bundler-audit
+        run: |
+          gem install bundler-audit -N
+          bundle-audit check --update
+      - name: brakeman
+        run: |
+          gem install brakeman -N
+          brakeman -q --no-pager

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ ENV['RAILS_ENV'] ||= 'test'
 
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
-require 'CSV'
+require 'csv'
 require "rspec/json_expectations"
 
 Rails.backtrace_cleaner.remove_silencers!


### PR DESCRIPTION
Implements plan items **P0.2** and **P2.9** from `plans/2026-07-07-legacy-review-fix-plan.md` (phase 1 of the fix series).

## Changes

- **P0.2** — `spec/spec_helper.rb`: `require 'CSV'` → `require 'csv'`. The uppercase form only loads on case-insensitive filesystems (macOS); on Linux the whole suite died with `LoadError` and ran 0 examples. This is why the suite has never run anywhere but a dev Mac.
- **P2.9** — `.github/workflows/ci.yml`: first CI in the repository. Test job (postgres:16 service, `rake db:create db:schema:load`, `bundle exec rspec`) plus a separate audit job (`bundler-audit`, `brakeman`).

## Verification (ruby:3.4.6 + postgres, Docker)

- Before: 0 examples, `LoadError` outside examples.
- After: **49 examples, 1 failure** — the known P0.1 golden-master ordering failure (`result_integration_spec.rb:122`, alliance blocks swap on equal vote sums). Fixed in the next PR of the series.

## Expected CI status on this PR

- `test` job: **red** with exactly the 1 known P0.1 failure until the P0.1 PR merges.
- `audit` job: **red** — bundler-audit currently flags rails 8.0.3 (needs 8.0.4.1), rack, rack-session, uri, etc. (plan item P1.2, phase 5 PR); brakeman flags the dead `render params[:target]` action (P1.10, later PR).

Merge order: this PR first — every later PR in the series relies on the suite loading and CI existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)