### PR TITLE
P0.3 + P0.9 + P1.6: Vote import trust boundary and HTTP client hardening

### DIFF
--- a/app/jobs/import_votes_job.rb
+++ b/app/jobs/import_votes_job.rb
@@ -9,9 +9,13 @@ class ImportVotesJob
                        .new(Vaalit::VotingApi::SUMMARY_URI)
                        .get
 
-    if !summary_response.is_a?(Net::HTTPSuccess) && summary_response.code.to_i == 401
+    if summary_response.code.to_i == 401
       Rails.logger.error 'Vote fetching failed due to HTTP 401 unauthorized. Ignoring retry.'
       return
+    end
+
+    unless summary_response.is_a?(Net::HTTPSuccess)
+      raise "Voting API summary request failed: HTTP #{summary_response.code}"
     end
 
     GlobalConfiguration.update_summary!(JSON.parse(summary_response.body))
@@ -19,7 +23,7 @@ class ImportVotesJob
     Rails.logger.info "Import votes to voting area #{@voting_area.name} (id: #{@voting_area.id})"
     vote_response = VotingApiRequest
                     .new(Vaalit::VotingApi::VOTES_URI)
-                    .get
+                    .get!
 
     csv_votes = vote_response.body
 

--- a/app/models/imported_csv_vote.rb
+++ b/app/models/imported_csv_vote.rb
@@ -20,7 +20,9 @@ class ImportedCsvVote
   # ehdokasnumero,ehdokasnimi,ääniä,vaaliliitto,vaaliliiton id
   #   0              1          2     3            4
   def convert(data)
-    @candidate_number = data[0].strip.to_i
-    @vote_count = data[2].strip.to_i
+    # Integer() raises on malformed input where to_i would silently
+    # truncate ("1O0" -> 1) or zero (""), corrupting the count.
+    @candidate_number = Integer(data[0].strip, 10)
+    @vote_count = Integer(data[2].strip, 10)
   end
 end

--- a/app/models/vote_importer.rb
+++ b/app/models/vote_importer.rb
@@ -13,9 +13,15 @@ class VoteImporter
   def create_votes!(csv)
     ActiveRecord::Base.transaction do
       begin
+        row_count = 0
         CSV.parse(csv, headers: true, col_sep: ",") do |row|
           ImportedCsvVote.create_from! row, voting_area_id: @voting_area.id
+          row_count += 1
         end
+
+        # An HTTP error body parses as a header-only CSV. Without this guard
+        # a zero-vote "result" would be calculated and published as real.
+        raise "Expected vote CSV to contain data rows, got none" if row_count.zero?
 
         @voting_area.submitted!
         @voting_area.ready!

--- a/app/requests/voting_api_request.rb
+++ b/app/requests/voting_api_request.rb
@@ -4,6 +4,15 @@ class VotingApiRequest
     @request = nil
   end
 
+  # As #get, but raises unless the response is a success. Use this from
+  # jobs so a failing Voting API call can never be mistaken for data.
+  def get!
+    response = get
+    return response if response.is_a?(Net::HTTPSuccess)
+
+    raise "Voting API request to #{@uri.path} failed: HTTP #{response.code}"
+  end
+
   def get
     http = init_http(@uri)
 
@@ -38,6 +47,10 @@ class VotingApiRequest
   def init_http(uri)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.scheme == "https"
+    # Net::HTTP defaults to 60s timeouts which can block the single
+    # delayed_job worker for minutes on election night.
+    http.open_timeout = 5
+    http.read_timeout = 30
 
     http
   end

--- a/config/initializers/000_vaalit.rb
+++ b/config/initializers/000_vaalit.rb
@@ -26,6 +26,12 @@ module Vaalit
     JWT_APIKEY         = ENV.fetch 'VOTING_API_JWT_APIKEY'
 
     BASE_URL           = ENV.fetch 'VOTING_API_BASE_URL'
+
+    if Rails.env.production? && !BASE_URL.start_with?('https://')
+      raise "VOTING_API_BASE_URL must use https in production (got: #{BASE_URL.inspect}); " \
+            "the bearer token and voter data would otherwise be sent in cleartext"
+    end
+
     VOTES_URI          = URI(BASE_URL + ENV.fetch('VOTING_API_VOTES_ENDPOINT'))
     VOTERS_URI         = URI(BASE_URL + ENV.fetch('VOTING_API_VOTERS_ENDPOINT'))
     SUMMARY_URI        = URI(BASE_URL + ENV.fetch('VOTING_API_SUMMARY_ENDPOINT'))

--- a/spec/models/imported_csv_vote_spec.rb
+++ b/spec/models/imported_csv_vote_spec.rb
@@ -24,6 +24,26 @@ RSpec.describe ImportedCsvVote, type: :model do
       expect(second.vote_count).to eq(32)
     end
 
+    it "raises on malformed numbers instead of truncating" do
+      data = <<~EOCSV
+        ehdokasnumero,ehdokasnimi,ääniä,vaaliliitto,vaaliliiton id
+        32,"Hanski, Anna",1O0,Akateemiset nallekarhut,2
+      EOCSV
+      row = CSV.parse(data, headers: true).first
+
+      expect { ImportedCsvVote.build_from(row) }.to raise_error(ArgumentError)
+    end
+
+    it "raises on empty vote amount instead of importing zero" do
+      data = <<~EOCSV
+        ehdokasnumero,ehdokasnimi,ääniä,vaaliliitto,vaaliliiton id
+        32,"Hanski, Anna",,Akateemiset nallekarhut,2
+      EOCSV
+      row = CSV.parse(data, headers: true).first
+
+      expect { ImportedCsvVote.build_from(row) }.to raise_error(StandardError)
+    end
+
     it "creates from csv" do
       coalition = FactoryBot.create :electoral_coalition
       alliance = FactoryBot.create :electoral_alliance,

--- a/spec/models/vote_importer_spec.rb
+++ b/spec/models/vote_importer_spec.rb
@@ -39,5 +39,23 @@ RSpec.describe VoteImporter, type: :model do
       expect(Vote.second.amount).to eq votes2
       expect(Vote.second.candidate_id).to eq candidates[1].id
     end
+
+    it "raises on a CSV without data rows and does not mark the area ready" do
+      area = FactoryBot.create :voting_area, ready: false, submitted: false
+      header_only = "ehdokasnumero,ehdokasnimi,ääniä,vaaliliitto,vaaliliiton id\n"
+
+      expect { VoteImporter.new(area).create_votes!(header_only) }
+        .to raise_error(/data rows/)
+      expect(area.reload.submitted).to eq false
+      expect(area.reload.ready).to eq false
+    end
+
+    it "raises on a non-CSV error body and does not mark the area ready" do
+      area = FactoryBot.create :voting_area, ready: false, submitted: false
+
+      expect { VoteImporter.new(area).create_votes!("<html>503 Service Unavailable</html>") }
+        .to raise_error(StandardError)
+      expect(area.reload.ready).to eq false
+    end
   end
 end


### PR DESCRIPTION
Implements plan items **P0.3**, **P0.9** and **P1.6** (phase 3 of the fix series). **Stacked on #31.**

## The bug this closes (P0.3, verified in the review)

`ImportVotesJob` never checked the votes response status. A 500/503 error body parses as a header-only CSV → **zero votes imported**, the voting area still marked `submitted!` + `ready!`, the error body uploaded to S3 as a votes CSV, and a zero-internet-votes result calculated and published — with the job reporting success (no retry, no Rollbar).

## Changes

- `ImportVotesJob`: summary response checked explicitly (401 stays a logged skip; any other non-success raises); votes fetched with the new `get!`.
- `VoteImporter#create_votes!`: raises if the parsed CSV contains no data rows — the last line of defense inside the import transaction.
- `ImportedCsvVote`: `Integer(x, 10)` instead of `to_i` for candidate number and amount. `to_i` silently truncated (`"1O0"` → 1 — which could also route votes to the wrong existing candidate) or zeroed (`""` → 0). This is the trust boundary for the entire count (P0.9).
- `VotingApiRequest`: new `get!` raising on non-success; explicit 5s open / 30s read timeouts (defaults are 60s each — enough to stall the single delayed_job worker on election night) (P1.6).
- Boot-time guard: production refuses to start with a non-https `VOTING_API_BASE_URL` — the bearer JWT and voter PII would otherwise go out cleartext (P1.6).

## Tests

New specs: header-only CSV and non-CSV error body both raise and leave the area unmarked; malformed/empty vote amounts raise. Full suite: **53 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)