### PR TITLE
P0.4–P0.6 + P0.10: Draw validation and freeze integrity

### DIFF
--- a/app/concerns/draw_behaviour.rb
+++ b/app/concerns/draw_behaviour.rb
@@ -1,6 +1,10 @@
 module DrawBehaviour
   extend ActiveSupport::Concern
 
+  # Raised when submitted draw orders are not a permutation of 1..n over
+  # exactly the draw's candidates. Shown to the operator by DrawsController.
+  InvalidDrawOrder = Class.new(StandardError)
+
   included do
     has_many :candidate_results, dependent: :nullify
 
@@ -44,11 +48,38 @@ module DrawBehaviour
       if automatically
         give_order_automatically!(order_attribute)
       else
-        draw_orders.each do |candidate_result_id, draw_order|
+        validated_draw_orders!(draw_orders).each do |candidate_result_id, draw_order|
           candidate_result = self.candidate_results.find(candidate_result_id)
           candidate_result.update!(order_attribute => draw_order)
         end
       end
+    end
+
+    # Blanks, garbage, duplicates or missing candidates would otherwise be
+    # written as NULL/0 and the tie silently resolved by physical row order:
+    # a seat decided by Postgres instead of by lot.
+    def validated_draw_orders!(draw_orders)
+      begin
+        given = (draw_orders || {}).map { |id, order|
+          [Integer(id.to_s, 10), Integer(order.to_s.strip, 10)]
+        }.to_h
+      rescue ArgumentError
+        raise InvalidDrawOrder,
+              "Arvontanumeroiden on oltava kokonaislukuja, tyhjiä arvoja ei hyväksytä."
+      end
+
+      member_ids = candidate_results.pluck(:id)
+      unless given.keys.sort == member_ids.sort
+        raise InvalidDrawOrder,
+              "Arvonnasta puuttuu ehdokkaita: jokaiselle arvonnan ehdokkaalle on annettava numero."
+      end
+
+      unless given.values.sort == (1..member_ids.size).to_a
+        raise InvalidDrawOrder,
+              "Arvontanumeroiden on oltava luvut 1..#{member_ids.size}, jokainen tasan kerran."
+      end
+
+      given
     end
 
     def drawable_candidates

--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -1,4 +1,8 @@
 class DrawsController < ApplicationController
+  rescue_from DrawBehaviour::InvalidDrawOrder do |error|
+    redirect_to draws_path, alert: error.message
+  end
+
   def index
     @result = Result.freezed.first
   end

--- a/app/models/candidate_result.rb
+++ b/app/models/candidate_result.rb
@@ -1,8 +1,12 @@
 class CandidateResult < ApplicationRecord
   belongs_to :result
   belongs_to :candidate
-  belongs_to :candidate_draw, dependent: :destroy
-  belongs_to :coalition_draw, dependent: :destroy
+  # optional: draws exist only for tied candidates. Explicit so that
+  # enabling belongs_to_required_by_default (Rails 5+ defaults) cannot
+  # break result calculation. No dependent: :destroy — a draw is shared
+  # by its whole tie group and belongs to the Result lifecycle.
+  belongs_to :candidate_draw, optional: true
+  belongs_to :coalition_draw, optional: true
 
   has_one :alliance_proportional,
           -> { where('alliance_proportionals.result_id = result_id') },

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -138,6 +138,8 @@ class Result < ApplicationRecord
   def candidate_draws_ready!
     return false unless self.freezed?
 
+    ensure_draws_complete!(candidate_draws, :candidate_draw_order)
+
     Result.transaction do
       update!(candidate_draws_ready: true)
       recalculate!
@@ -153,6 +155,8 @@ class Result < ApplicationRecord
   def alliance_draws_ready!
     return false unless self.candidate_draws_ready?
 
+    ensure_draws_complete!(alliance_draws, :alliance_draw_order)
+
     Result.transaction do
       update!(alliance_draws_ready: true)
       recalculate!
@@ -167,6 +171,8 @@ class Result < ApplicationRecord
   # Alliance draws must be marked ready result can be finalized.
   def finalize!
     return false unless self.alliance_draws_ready?
+
+    ensure_draws_complete!(coalition_draws, :coalition_draw_order)
 
     Result.transaction do
       self.update!(final: true, coalition_draws_ready: true)
@@ -298,6 +304,8 @@ class Result < ApplicationRecord
 
   def create_candidate_draws!
     CandidateDraw.where(result_id: self.id).destroy_all
+    # Stale order values from destroyed draws must not leak into new draws.
+    candidate_results.update_all(candidate_draw_order: nil)
     CandidateResult.find_duplicate_vote_sums(self.id).each_with_index do |draw, index|
       candidate_ids = ElectoralAlliance.find(draw.electoral_alliance_id).candidate_ids
       draw_candidate_results =
@@ -329,6 +337,8 @@ class Result < ApplicationRecord
 
   def create_proportional_draws!(draw_class, proportional_class)
     draw_class.where(result_id: self.id).destroy_all
+    # Stale order values from destroyed draws must not leak into new draws.
+    candidate_results.update_all("#{draw_class.name.underscore}_order" => nil)
 
     proportional_class.find_duplicate_numbers(self.id).each_with_index do |draw_proportional, index|
       draw_candidate_ids = proportional_class.find_draw_candidate_ids_of(draw_proportional, self.id)
@@ -345,6 +355,20 @@ class Result < ApplicationRecord
 
   def find_candidate_results_for(candidate_ids)
     candidate_results.where(["candidate_id IN (?)", candidate_ids])
+  end
+
+  # A stage may only advance when every draw of that stage has a complete
+  # set of order values (a permutation of 1..n). An unfilled draw would be
+  # silently resolved by physical row order: a seat decided by Postgres
+  # instead of by lot.
+  def ensure_draws_complete!(draws, order_attribute)
+    draws.each do |draw|
+      orders = draw.candidate_results.pluck(order_attribute)
+      next if orders.none?(&:nil?) && orders.sort == (1..orders.size).to_a
+
+      raise "#{draw.class.name} #{draw.identifier} has missing or duplicate " \
+            "#{order_attribute} values: #{orders.inspect}"
+    end
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -11,6 +11,13 @@ class Vote < ApplicationRecord
 
   default_scope { includes(:candidate).order('candidates.candidate_number') }
 
+  # A frozen result freezes vote_sum_cache but later stages still read the
+  # live votes table (proportional recalculation). Votes must therefore be
+  # immutable from freeze onwards or the final result would mix old and new
+  # sums.
+  before_save :forbid_mutation_when_result_frozen!
+  before_destroy :forbid_mutation_when_result_frozen!
+
   def self.countable_sum
     countable.sum('COALESCE(votes.fixed_amount, votes.amount)')
   end
@@ -19,5 +26,11 @@ class Vote < ApplicationRecord
 
   def must_have_positive_amount
     errors.add :base, "Must have positive vote amount" if amount&.negative? || fixed_amount&.negative?
+  end
+
+  def forbid_mutation_when_result_frozen!
+    return unless Result.freezed.any? || Result.final.any?
+
+    raise "Votes cannot be created or changed while a frozen or final result exists"
   end
 end

--- a/app/models/voting_area.rb
+++ b/app/models/voting_area.rb
@@ -26,6 +26,10 @@ class VotingArea < ApplicationRecord
   end
 
   def ready!
+    if Result.freezed.any? || Result.final.any?
+      raise "Voting areas cannot be marked ready while a frozen or final result exists"
+    end
+
     update! ready: true
   end
 

--- a/spec/models/draw_behaviour_spec.rb
+++ b/spec/models/draw_behaviour_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe DrawBehaviour, type: :model do
+  let(:result) { FactoryBot.create :result }
+  let(:draw) { CandidateDraw.create! result: result, identifier_number: 0 }
+  let(:candidate_results) do
+    Array.new(3) do
+      CandidateResult.create!(
+        result: result,
+        candidate: FactoryBot.create(:candidate),
+        vote_sum_cache: 10,
+        candidate_draw: draw
+      )
+    end
+  end
+  let(:ids) { candidate_results.map(&:id) }
+
+  describe "#give_order!" do
+    it "stores a valid permutation of 1..n" do
+      draw.give_order!(:candidate_draw_order, { ids[0] => "2", ids[1] => "3", ids[2] => "1" })
+
+      expect(candidate_results.map { |cr| cr.reload.candidate_draw_order }).to eq [2, 3, 1]
+    end
+
+    it "raises on blank order values" do
+      expect {
+        draw.give_order!(:candidate_draw_order, { ids[0] => "", ids[1] => "1", ids[2] => "2" })
+      }.to raise_error(DrawBehaviour::InvalidDrawOrder)
+    end
+
+    it "raises on non-numeric order values" do
+      expect {
+        draw.give_order!(:candidate_draw_order, { ids[0] => "abc", ids[1] => "1", ids[2] => "2" })
+      }.to raise_error(DrawBehaviour::InvalidDrawOrder)
+    end
+
+    it "raises on duplicate order values" do
+      expect {
+        draw.give_order!(:candidate_draw_order, { ids[0] => "1", ids[1] => "1", ids[2] => "2" })
+      }.to raise_error(DrawBehaviour::InvalidDrawOrder)
+    end
+
+    it "raises when a draw member is missing from the submitted orders" do
+      expect {
+        draw.give_order!(:candidate_draw_order, { ids[0] => "1", ids[1] => "2" })
+      }.to raise_error(DrawBehaviour::InvalidDrawOrder)
+    end
+
+    it "raises when orders are not 1..n" do
+      expect {
+        draw.give_order!(:candidate_draw_order, { ids[0] => "1", ids[1] => "2", ids[2] => "4" })
+      }.to raise_error(DrawBehaviour::InvalidDrawOrder)
+    end
+
+    it "writes nothing when validation fails" do
+      begin
+        draw.give_order!(:candidate_draw_order, { ids[0] => "1", ids[1] => "2", ids[2] => "x" })
+      rescue DrawBehaviour::InvalidDrawOrder
+        nil
+      end
+
+      expect(candidate_results.map { |cr| cr.reload.candidate_draw_order }).to eq [nil, nil, nil]
+    end
+  end
+end

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe Result, type: :model do
+  describe "#candidate_draws_ready!" do
+    let(:result) { FactoryBot.create :result, freezed: true }
+    let(:draw) { CandidateDraw.create! result: result, identifier_number: 0 }
+
+    before do
+      2.times do
+        CandidateResult.create!(
+          result: result,
+          candidate: FactoryBot.create(:candidate),
+          vote_sum_cache: 10,
+          candidate_draw: draw
+        )
+      end
+    end
+
+    it "raises when a candidate draw has no order values" do
+      expect { result.candidate_draws_ready! }
+        .to raise_error(/missing or duplicate candidate_draw_order/)
+      expect(result.reload.candidate_draws_ready).to eq false
+    end
+
+    it "raises when a candidate draw has duplicate order values" do
+      result.candidate_results.each { |cr| cr.update! candidate_draw_order: 1 }
+
+      expect { result.candidate_draws_ready! }
+        .to raise_error(/missing or duplicate candidate_draw_order/)
+    end
+
+    it "advances when every draw has a complete permutation" do
+      result.candidate_results.each_with_index do |cr, i|
+        cr.update! candidate_draw_order: i + 1
+      end
+
+      expect(result.candidate_draws_ready!).to eq result
+      expect(result.reload.candidate_draws_ready).to eq true
+    end
+  end
+
+  describe "draw recreation" do
+    let(:result) { FactoryBot.create :result }
+
+    it "clears stale alliance and coalition draw orders" do
+      candidate_result = CandidateResult.create!(
+        result: result,
+        candidate: FactoryBot.create(:candidate),
+        vote_sum_cache: 10,
+        alliance_draw_order: 2,
+        coalition_draw_order: 3
+      )
+
+      result.send(:create_alliance_draws!)
+      result.send(:create_coalition_draws!)
+
+      candidate_result.reload
+      expect(candidate_result.alliance_draw_order).to be_nil
+      expect(candidate_result.coalition_draw_order).to be_nil
+    end
+  end
+end

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe Vote, type: :model do
+  describe "freeze integrity" do
+    it "forbids creating or changing votes while a frozen result exists" do
+      vote = FactoryBot.create :vote
+
+      FactoryBot.create :result, freezed: true
+
+      expect { vote.update! fixed_amount: 999 }
+        .to raise_error(/frozen or final result/)
+      expect { FactoryBot.create :vote }
+        .to raise_error(/frozen or final result/)
+      expect { vote.destroy! }
+        .to raise_error(/frozen or final result/)
+    end
+
+    it "forbids marking a voting area ready while a frozen result exists" do
+      area = FactoryBot.create :voting_area, ready: false, submitted: true
+
+      FactoryBot.create :result, freezed: true
+
+      expect { area.ready! }.to raise_error(/frozen or final result/)
+      expect(area.reload.ready).to eq false
+    end
+  end
+end


### PR DESCRIPTION
Implements plan items **P0.4**, **P0.5**, **P0.6** and **P0.10** (phase 4 of the fix series). **Stacked on #32.**

## Changes

- **P0.4** — `give_order!` now validates that the submitted orders cover exactly the draw's candidates with a permutation of 1..n. Blanks (previously stored as NULL), garbage (`"abc"` → 0) and duplicates raise `DrawBehaviour::InvalidDrawOrder`, which `DrawsController` shows as a flash alert. Additionally `candidate_draws_ready!` / `alliance_draws_ready!` / `finalize!` hard-check that no draw of their stage has missing or duplicate order values — an unfilled draw was previously resolved silently by physical row order (a seat decided by Postgres instead of by lot).
- **P0.5** — draw recreation (`create_candidate_draws!` / `create_proportional_draws!`) clears the corresponding `*_draw_order` columns. Stale orders from destroyed draws no longer leak into new tie groups.
- **P0.6** — votes are now immutable (create/update/destroy) and voting areas cannot be marked ready while a frozen or final result exists. Chosen over rewriting the proportional calculation to read frozen caches: the guard is a far smaller diff and makes the "recompute from live votes" in later stages provably equal to the frozen sums. Previously this was guarded only by operator discipline.
- **P0.10** — `CandidateResult` draw associations get explicit `optional: true` (a `belongs_to_required_by_default` activation can no longer hard-break result calculation) and lose `dependent: :destroy`, which used to destroy the *shared* draw record of the whole tie group when one member was destroyed.

## Tests

13 new examples: permutation validation (blank/garbage/duplicate/missing/wrong range/atomicity), stage advancement checks, stale-order clearing, freeze-immutability guards. Full suite: **66 examples, 0 failures** — the certified 2009 draw orders pass the new permutation checks, confirming they encode per-group 1..n draws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)