### PR TITLE
P2.1–P2.7: Election-night reliability batch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,10 @@ AWS_SECRET_ACCESS_KEY=""
 AWS_S3_BUCKET_NAME="vaalitulostin-qa"
 RESULT_ADDRESS="https://s3.amazonaws.com/vaalitulostin-qa"
 
+# S3 year directory for published results. Set explicitly per election;
+# defaults to the current year at the time of publishing.
+RESULTS_YEAR="2026"
+
 TZ="Europe/Helsinki"
 
 # Limit concurrency only in development to speed up server reloading

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,5 @@
 web: bundle exec puma -C config/puma.rb
+# NOTE: exactly ONE worker. Job ordering between import/publish/create-result
+# jobs relies on a single delayed_job worker; scaling this up requires adding
+# locking in many places.
 worker:  bundle exec rake jobs:work

--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -38,7 +38,10 @@ class DrawsController < ApplicationController
   end
 
   def enqueue(job)
-    Result.freezed.first.in_process!
+    result = Result.freezed.first
+    raise ActiveRecord::RecordNotFound, "No frozen result exists" if result.nil?
+
+    result.in_process!
     Delayed::Job.enqueue(job)
   end
 

--- a/app/decorators/result_decorator.rb
+++ b/app/decorators/result_decorator.rb
@@ -45,7 +45,7 @@ class ResultDecorator < ApplicationDecorator
   end
 
   def result_file_url
-    "#{Vaalit::Results::PUBLIC_RESULT_URL}/#{filename}"
+    "#{Vaalit::Results.public_result_url}/#{filename}"
   end
 
   def to_html

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def chart_address(result, chart_type)
-    base_url = Vaalit::Results::PUBLIC_RESULT_URL
+    base_url = Vaalit::Results.public_result_url
     name = chart_type == :candidates ? "candidates" : "result"
 
     "#{base_url}/#{chart_type}.html?json=#{result.filename('.json', name)}"

--- a/app/jobs/alliance_draws_ready_job.rb
+++ b/app/jobs/alliance_draws_ready_job.rb
@@ -1,5 +1,19 @@
 class AllianceDrawsReadyJob
   def perform
-    Result.alliance_draws_ready!
+    result = Result.freezed.first
+    raise "Cannot mark alliance draws ready: no frozen result exists" if result.nil?
+
+    Rails.logger.info "Marking alliance draws ready and calculating new coalition draws!"
+    if result.alliance_draws_ready! == false
+      raise "Cannot mark alliance draws ready: candidate draws are not ready"
+    end
+  rescue StandardError
+    Result.freezed.first&.processed!
+    raise
+  end
+
+  # Precondition failures are permanent, do not retry.
+  def max_attempts
+    1
   end
 end

--- a/app/jobs/candidate_draws_ready_job.rb
+++ b/app/jobs/candidate_draws_ready_job.rb
@@ -1,5 +1,19 @@
 class CandidateDrawsReadyJob
   def perform
-    Result.candidate_draws_ready!
+    result = Result.freezed.first
+    raise "Cannot mark candidate draws ready: no frozen result exists" if result.nil?
+
+    Rails.logger.info "Marking candidate draws ready and calculating new alliance draws!"
+    if result.candidate_draws_ready! == false
+      raise "Cannot mark candidate draws ready: result is not frozen"
+    end
+  rescue StandardError
+    Result.freezed.first&.processed!
+    raise
+  end
+
+  # Precondition failures are permanent, do not retry.
+  def max_attempts
+    1
   end
 end

--- a/app/jobs/create_final_result_job.rb
+++ b/app/jobs/create_final_result_job.rb
@@ -1,7 +1,22 @@
 class CreateFinalResultJob
   def perform
-    result = Result.finalize!
+    result = Result.freezed.first
+    raise "Cannot finalize: no frozen result exists" if result.nil?
+
+    Rails.logger.info "Creating the Final Result"
+    if result.finalize! == false
+      raise "Cannot finalize: alliance draws have not been marked ready"
+    end
 
     ResultPublisher.store_to_s3!(result)
+  rescue StandardError
+    Result.freezed.first&.processed!
+    raise
+  end
+
+  # Precondition failures are permanent; retrying would only let a stale
+  # job finalize the election unexpectedly later.
+  def max_attempts
+    1
   end
 end

--- a/app/jobs/import_votes_by_faculty_job.rb
+++ b/app/jobs/import_votes_by_faculty_job.rb
@@ -17,5 +17,16 @@ class ImportVotesByFacultyJob
 
     Rails.logger.info "Create Job to publish votes by faculty"
     Delayed::Job.enqueue(PublishVotesByFacultyJob.new(response.body))
+  ensure
+    # The 5-minute loop lives here at its head so that no failure mode
+    # (API error, S3 outage, exhausted retries) can silently kill it.
+    Rails.logger.info "Reschedule next import of votes by faculty"
+    Delayed::Job.enqueue(ImportVotesByFacultyJob.new, run_at: 5.minutes.from_now)
+  end
+
+  # The loop itself retries in 5 minutes; delayed_job retries would
+  # multiply the loop into duplicate chains.
+  def max_attempts
+    1
   end
 end

--- a/app/jobs/import_votes_by_hour_job.rb
+++ b/app/jobs/import_votes_by_hour_job.rb
@@ -17,5 +17,16 @@ class ImportVotesByHourJob
 
     Rails.logger.info "Create Job to publish votes by hour"
     Delayed::Job.enqueue(PublishVotesByHourJob.new(response.body))
+  ensure
+    # The 5-minute loop lives here at its head so that no failure mode
+    # (API error, S3 outage, exhausted retries) can silently kill it.
+    Rails.logger.info "Reschedule next import of votes by hour"
+    Delayed::Job.enqueue(ImportVotesByHourJob.new, run_at: 5.minutes.from_now)
+  end
+
+  # The loop itself retries in 5 minutes; delayed_job retries would
+  # multiply the loop into duplicate chains.
+  def max_attempts
+    1
   end
 end

--- a/app/jobs/import_votes_by_voter_start_year_job.rb
+++ b/app/jobs/import_votes_by_voter_start_year_job.rb
@@ -17,5 +17,16 @@ class ImportVotesByVoterStartYearJob
 
     Rails.logger.info "Create Job to publish votes by voter_start_year"
     Delayed::Job.enqueue(PublishVotesByVoterStartYearJob.new(response.body))
+  ensure
+    # The 5-minute loop lives here at its head so that no failure mode
+    # (API error, S3 outage, exhausted retries) can silently kill it.
+    Rails.logger.info "Reschedule next import of votes by voter start year"
+    Delayed::Job.enqueue(ImportVotesByVoterStartYearJob.new, run_at: 5.minutes.from_now)
+  end
+
+  # The loop itself retries in 5 minutes; delayed_job retries would
+  # multiply the loop into duplicate chains.
+  def max_attempts
+    1
   end
 end

--- a/app/jobs/publish_votes_by_faculty_job.rb
+++ b/app/jobs/publish_votes_by_faculty_job.rb
@@ -11,8 +11,5 @@ class PublishVotesByFacultyJob
     S3Publisher
       .new
       .store_s3_object('votes_by_faculty.json', json_data, 'application/json')
-
-    Rails.logger.info 'Reschedule next import of votes by faculty'
-    Delayed::Job.enqueue(ImportVotesByFacultyJob.new, run_at: 5.minutes.from_now)
   end
 end

--- a/app/jobs/publish_votes_by_hour_job.rb
+++ b/app/jobs/publish_votes_by_hour_job.rb
@@ -11,8 +11,5 @@ class PublishVotesByHourJob
     S3Publisher
       .new
       .store_s3_object('votes_by_hour.json', json_data, 'application/json')
-
-    Rails.logger.info 'Reschedule next import of votes by hour'
-    Delayed::Job.enqueue(ImportVotesByHourJob.new, run_at: 5.minutes.from_now)
   end
 end

--- a/app/jobs/publish_votes_by_voter_start_year_job.rb
+++ b/app/jobs/publish_votes_by_voter_start_year_job.rb
@@ -11,8 +11,5 @@ class PublishVotesByVoterStartYearJob
     S3Publisher
       .new
       .store_s3_object('votes_by_voter_start_year.json', json_data, 'application/json')
-
-    Rails.logger.info 'Reschedule next import of votes by voter start year'
-    Delayed::Job.enqueue(ImportVotesByVoterStartYearJob.new, run_at: 5.minutes.from_now)
   end
 end

--- a/app/models/global_configuration.rb
+++ b/app/models/global_configuration.rb
@@ -10,30 +10,40 @@ class GlobalConfiguration < ApplicationRecord
     Vaalit::Public::EMAIL_FROM_NAME
   end
 
+  # Raises on unexpected summary JSON (missing keys or null values)
+  # instead of writing nils, which would later break result rendering
+  # (sprintf "%6d", nil).
   def self.update_summary!(data)
-    c = first
+    values = %w[votes_given votes_accepted voter_count voting_percentage]
+             .to_h { |key| [key, data.fetch(key)] }
 
-    c.votes_given            = data["votes_given"]
-    c.votes_accepted         = data["votes_accepted"]
-    c.potential_voters_count = data["voter_count"]
-    c.voting_percentage      = data["voting_percentage"]
+    if values.values.any?(&:nil?)
+      raise "Voting API summary has null values: #{values.inspect}"
+    end
+
+    c = first!
+
+    c.votes_given            = values.fetch("votes_given")
+    c.votes_accepted         = values.fetch("votes_accepted")
+    c.potential_voters_count = values.fetch("voter_count")
+    c.voting_percentage      = values.fetch("voting_percentage")
 
     c.save!
   end
 
   def self.votes_given
-    first.votes_given
+    first!.votes_given
   end
 
   def self.votes_accepted
-    first.votes_accepted
+    first!.votes_accepted
   end
 
   def self.potential_voters_count
-    first.potential_voters_count
+    first!.potential_voters_count
   end
 
   def self.voting_percentage
-    first.voting_percentage
+    first!.voting_percentage
   end
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -85,21 +85,6 @@ class Result < ApplicationRecord
     self.create! freezed: true
   end
 
-  def self.candidate_draws_ready!
-    Rails.logger.info "Marking candidate draws ready and calculating new alliance draws!"
-    Result.freezed.first.candidate_draws_ready!
-  end
-
-  def self.alliance_draws_ready!
-    Rails.logger.info "Marking alliance draws ready and calculating new coalition draws!"
-    Result.freezed.first.alliance_draws_ready!
-  end
-
-  def self.finalize!
-    Rails.logger.info "Creating the Final Result"
-    Result.freezed.first.finalize!
-  end
-
   def processed!
     update!(in_process: false)
   end
@@ -294,7 +279,10 @@ class Result < ApplicationRecord
       )
     end
 
-    self.update!(vote_sum_cache: Vote.countable_sum)
+    # Sum over the rows just created, not a second query against votes:
+    # under READ COMMITTED an area flipping ready mid-calculation could
+    # otherwise make the published total disagree with the candidate rows.
+    self.update!(vote_sum_cache: candidate_results.sum(:vote_sum_cache))
   end
 
   def elect_candidates!

--- a/app/models/result_publisher.rb
+++ b/app/models/result_publisher.rb
@@ -53,7 +53,7 @@ class ResultPublisher
   end
 
   def directory
-    Vaalit::Results::DIRECTORY
+    Vaalit::Results.directory
   end
 
   def bucket_name

--- a/app/models/s3_publisher.rb
+++ b/app/models/s3_publisher.rb
@@ -1,6 +1,6 @@
 class S3Publisher
   def directory
-    Vaalit::Results::DIRECTORY
+    Vaalit::Results.directory
   end
 
   def bucket_name
@@ -23,7 +23,7 @@ class S3Publisher
 
   def test_write
     put_object(
-      key: "#{Vaalit::Results::DIRECTORY}/lulz.txt",
+      key: "#{Vaalit::Results.directory}/lulz.txt",
       body: "Lulz UTF8 Ääkkönen: #{Time.now.utc}",
       content_type: 'text/html; charset=utf-8'
     )

--- a/app/views/manage/results/index.html.erb
+++ b/app/views/manage/results/index.html.erb
@@ -4,13 +4,13 @@
 
 <h1>Vaalitulokset</h1>
 
-Julkinen vaalitulos: <%= link_to Vaalit::Results::PUBLIC_RESULT_URL, Vaalit::Results::PUBLIC_RESULT_URL %>
+Julkinen vaalitulos: <%= link_to Vaalit::Results.public_result_url, Vaalit::Results.public_result_url %>
 
 <h2>Alustavat vaalitulokset</h2>
 
 <ul>
   <li>Vaalituloksen julkinen osoite pysyy aina samana:
-    <%= link_to Vaalit::Results::PUBLIC_RESULT_URL, Vaalit::Results::PUBLIC_RESULT_URL %></li>
+    <%= link_to Vaalit::Results.public_result_url, Vaalit::Results.public_result_url %></li>
   <li>Tuloksen julkaiseminen päivittää tiedot yllämainittuun osoitteeseen.</li>
   <li>Linkitä HYYn websivuilta ainoastaan julkiseen osoitteeseen.</li>
   <li>Väliaikatulos on tarkoitettu tiedotuksen ja vaalivalvojaisten käyttöön ennen tuloksen julkaisua.</li>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,8 +53,15 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  # Deliver via AWS SES (aws-actionmailer-ses); raise so a broken admin
+  # password reset is visible instead of silently swallowed.
+  config.action_mailer.delivery_method = :ses_v2
+  config.action_mailer.raise_delivery_errors = true
+
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = {
+    host: URI(ENV.fetch("SITE_ADDRESS")).host
+  }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/config/initializers/000_vaalit.rb
+++ b/config/initializers/000_vaalit.rb
@@ -17,9 +17,17 @@ module Vaalit
     AWS_S3_BASE_URL     = ENV.fetch 'AWS_S3_BASE_URL'
 
     RESULT_ADDRESS  = ENV.fetch 'RESULT_ADDRESS'
-    DIRECTORY       = Time.now.year
-    PUBLIC_RESULT_URL = "#{RESULT_ADDRESS}/#{DIRECTORY}"
 
+    # Evaluated per use, not frozen at boot: web and worker restarted
+    # across New Year would otherwise publish to different S3 year
+    # directories. Set RESULTS_YEAR explicitly per election.
+    def self.directory
+      ENV.fetch('RESULTS_YEAR') { Time.now.year.to_s }
+    end
+
+    def self.public_result_url
+      "#{RESULT_ADDRESS}/#{directory}"
+    end
   end
 
   module VotingApi

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,7 @@
+# Election-night sanity limits. The delayed_job defaults are
+# max_attempts = 25 (exponential backoff spanning ~3 weeks) and
+# max_run_time = 4 hours - a single misbehaving job would occupy the
+# only worker and spam Rollbar for weeks. Jobs whose failures are
+# permanent (violated preconditions) define max_attempts = 1 themselves.
+Delayed::Worker.max_attempts = 5
+Delayed::Worker.max_run_time = 30.minutes

--- a/db/migrate/20260707130000_add_single_frozen_result_constraints.rb
+++ b/db/migrate/20260707130000_add_single_frozen_result_constraints.rb
@@ -1,0 +1,10 @@
+class AddSingleFrozenResultConstraints < ActiveRecord::Migration[8.0]
+  # Belt and suspenders for the check-then-act guard in
+  # Result.freeze_for_draws!: two workers or a double-click could
+  # otherwise create two frozen results, and all draw code uses
+  # Result.freezed.first.
+  def change
+    add_index :results, "(1)", unique: true, where: "freezed", name: "index_results_only_one_freezed"
+    add_index :results, "(1)", unique: true, where: "final", name: "index_results_only_one_final"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_07_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_07_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -213,6 +213,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_07_120000) do
     t.integer "vote_sum_cache", default: 0, null: false
     t.boolean "published", default: false, null: false
     t.boolean "published_pending", default: false, null: false
+    t.index "(1)", name: "index_results_only_one_final", unique: true, where: "final"
+    t.index "(1)", name: "index_results_only_one_freezed", unique: true, where: "freezed"
   end
 
   create_table "voters", force: :cascade do |t|


### PR DESCRIPTION
Implements plan items **P2.1–P2.7** (phase 7 of the fix series). **Stacked on #35.**

## Changes

- **P2.1** — production mail delivers via `:ses_v2` (aws-actionmailer-ses was bundled but never configured — "forgot password" was a guaranteed 500 via SMTP localhost:25). Mailer host comes from `SITE_ADDRESS` instead of `example.com`. *Send a test reset before every election.*
- **P2.2** — `Delayed::Worker.max_attempts = 5`, `max_run_time = 30.minutes` (defaults: 25 attempts over ~3 weeks, 4h runtime, on the single worker).
- **P2.3** — draw-stage jobs (`CreateFinalResultJob`, `CandidateDrawsReadyJob`, `AllianceDrawsReadyJob`) fail fast with explicit precondition errors, `max_attempts 1` (a stale retry could otherwise silently finalize the election later) and reset `in_process` on failure so the operator UI can't stick. The nil-crashing `Result` class-level stage methods are deleted. `DrawsController#enqueue` guards the nil frozen result. `GlobalConfiguration` raises clearly on unseeded DB / malformed summary JSON instead of writing nils that break rendering.
- **P2.4** — the 5-minute stats loops reschedule in `ensure` at the loop head (import job) instead of the paired publish job; no failure mode can silently kill a loop anymore. 401 stays a logged skip. `max_attempts 1` so DJ retries can't fork duplicate loop chains.
- **P2.5** — partial unique indexes allow at most one `freezed` and one `final` result at the DB level (verified to survive a schema.rb dump/load round trip and to reject a second frozen row). Procfile documents the single-worker assumption.
- **P2.6** — S3 year directory is now evaluated per use and overridable with `RESULTS_YEAR` (was `Time.now.year` frozen at boot → New Year restart split publishing across two year directories).
- **P2.7** — the published vote total is summed from the just-created `candidate_results` rows instead of a second query against live votes, so the total always agrees with the candidate rows.

## Verification

Full suite: **67 examples, 0 failures**, golden master byte-identical. Includes a migration (the two partial indexes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)