### PR TITLE
P0.7 + P0.8 + P3.3: Exact tie detection, no vanishing candidates, schema integrity

### DIFF
--- a/app/concerns/proportion_calculations.rb
+++ b/app/concerns/proportion_calculations.rb
@@ -2,24 +2,34 @@ module ProportionCalculations
   extend ActiveSupport::Concern
 
   included do
+    # Display value only. Two distinct proportionals can round to the
+    # same 5 decimals (difference can be as small as 1/(i*j)); ties are
+    # detected from the exact fraction below, never from this number.
     def self.calculate_proportional(votes, array_index)
       (votes.to_f / (array_index + 1)).round(Vaalit::Voting::PROPORTIONAL_PRECISION)
+    end
+
+    # Exact value of the proportional as a reduced fraction.
+    def self.proportional_fraction(votes, array_index)
+      Rational(votes, array_index + 1)
     end
   end
 
   module ClassMethods
-    def create_or_update!(result_id:, candidate_id:, number:)
+    def create_or_update!(result_id:, candidate_id:, number:, numerator:, denominator:)
       existing =
         where(candidate_id: candidate_id)
         .find_by(result_id: result_id)
 
       if existing.present?
-        existing.update!(number: number)
+        existing.update!(number: number, numerator: numerator, denominator: denominator)
       else
         self.create!(
           result_id: result_id,
           candidate_id: candidate_id,
-          number: number
+          number: number,
+          numerator: numerator,
+          denominator: denominator
         )
       end
     end

--- a/app/models/alliance_proportional.rb
+++ b/app/models/alliance_proportional.rb
@@ -4,7 +4,7 @@ class AllianceProportional < ApplicationRecord
   belongs_to :result
   belongs_to :candidate
 
-  validates :result_id, :candidate_id, :number, presence: true
+  validates :result_id, :candidate_id, :number, :numerator, :denominator, presence: true
 
   # For each coalition C,
   # iterate through all its alliances
@@ -19,6 +19,14 @@ class AllianceProportional < ApplicationRecord
   # The number in question is the alliance proportional.
   # rubocop:disable Rails/FindEach
   def self.calculate!(result)
+    # An alliance without a coalition would silently get no
+    # proportionals and its candidates could never be elected. The
+    # import bypasses model validations, so check here (P0.8).
+    orphans = ElectoralAlliance.without_coalition
+    if orphans.exists?
+      raise "Electoral alliances without a coalition: #{orphans.pluck(:shorten).join(', ')}"
+    end
+
     ElectoralCoalition.all.each do |coalition|
       coalition.electoral_alliances.each do |alliance|
         alliance_votes = alliance.votes.countable_sum
@@ -31,10 +39,13 @@ class AllianceProportional < ApplicationRecord
         alliance
           .candidates.with_vote_sums_for(result)
           .each_with_index do |candidate, array_index|
+          fraction = proportional_fraction(alliance_votes, array_index)
           self.create_or_update!(
             result_id: result.id,
             candidate_id: candidate.id,
-            number: calculate_proportional(alliance_votes, array_index)
+            number: calculate_proportional(alliance_votes, array_index),
+            numerator: fraction.numerator,
+            denominator: fraction.denominator
           )
         end
       end
@@ -42,13 +53,18 @@ class AllianceProportional < ApplicationRecord
   end
   # rubocop:enable Rails/FindEach
 
+  # Ties are groups with the same exact fraction (reduced numerator and
+  # denominator), never the rounded display number (P0.7).
   def self.find_duplicate_numbers(result_id)
-    select("electoral_alliances.electoral_coalition_id, alliance_proportionals.number")
+    select("electoral_alliances.electoral_coalition_id,
+            alliance_proportionals.numerator, alliance_proportionals.denominator")
       .joins('INNER JOIN candidates ON alliance_proportionals.candidate_id = candidates.id')
       .joins('INNER JOIN electoral_alliances ON  candidates.electoral_alliance_id = electoral_alliances.id')
       .where("alliance_proportionals.result_id = ?", result_id)
-      .group("electoral_alliances.electoral_coalition_id, alliance_proportionals.number having count(*) > 1")
-      .order("alliance_proportionals.number desc, electoral_alliances.electoral_coalition_id asc")
+      .group("electoral_alliances.electoral_coalition_id,
+              alliance_proportionals.numerator, alliance_proportionals.denominator having count(*) > 1")
+      .order(Arel.sql("(alliance_proportionals.numerator::float8 / alliance_proportionals.denominator) desc,
+              electoral_alliances.electoral_coalition_id asc"))
   end
 
   def self.find_draw_candidate_ids_of(draw_proportional, result_id)
@@ -56,8 +72,9 @@ class AllianceProportional < ApplicationRecord
       .joins('INNER JOIN candidates ON alliance_proportionals.candidate_id = candidates.id')
       .joins('INNER JOIN electoral_alliances ON candidates.electoral_alliance_id = electoral_alliances.id')
       .where(
-        "number = ? AND result_id = ? AND electoral_coalition_id = ?",
-        draw_proportional.number,
+        "numerator = ? AND denominator = ? AND result_id = ? AND electoral_coalition_id = ?",
+        draw_proportional.numerator,
+        draw_proportional.denominator,
         result_id,
         draw_proportional.electoral_coalition_id
       ).map(&:candidate_id)

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -43,24 +43,24 @@ class Candidate < ApplicationRecord
 
   # Calculates all votes from all 'ready' (calculable) voting areas for each candidate.
   # If there exists a fixed vote amount, it will be used instead of the preliminary amount.
+  # The ready-area condition lives in the JOIN, not the WHERE: a candidate whose votes
+  # are all in a non-ready area must still appear with sum 0, exactly like a candidate
+  # with no votes at all (P0.8).
   def self.with_vote_sums_for(result)
     votable.select('candidates.id, SUM(COALESCE(votes.fixed_amount, votes.amount, 0)) as vote_sum').joins(
-     'LEFT JOIN  votes                 ON votes.candidate_id = candidates.id').joins(
-     'LEFT JOIN  candidate_results     ON candidate_results.candidate_id = candidates.id').joins(
-     'LEFT JOIN  voting_areas          ON voting_areas.id = votes.voting_area_id').where(
-      '(votes.candidate_id = candidates.id OR votes.candidate_id IS NULL)
-         AND (voting_areas.ready = ?                 OR voting_areas.ready IS NULL)
-         AND (candidate_results.result_id = ?        OR candidate_results.result_id IS NULL)
-         AND (votes.voting_area_id = voting_areas.id OR votes.voting_area_id IS NULL)', true, result.id).group(
+     'LEFT JOIN  votes                 ON votes.candidate_id = candidates.id
+         AND votes.voting_area_id IN (SELECT id FROM voting_areas WHERE ready = TRUE)').joins(
+     'LEFT JOIN  candidate_results     ON candidate_results.candidate_id = candidates.id').where(
+      'candidate_results.result_id = ? OR candidate_results.result_id IS NULL', result.id).group(
       'candidates.id, candidate_results.candidate_draw_order').order(
       'vote_sum desc, candidate_results.candidate_draw_order asc, candidates.id asc')
   end
 
   def self.with_vote_sums
     votable.select('candidates.id, SUM(COALESCE(votes.fixed_amount, votes.amount, 0)) as vote_sum').joins(
-      'LEFT JOIN "votes" ON "votes"."candidate_id" = "candidates"."id"').joins(
-      'LEFT JOIN "voting_areas" ON "voting_areas"."id" = "votes"."voting_area_id"').where(
-      'voting_areas.ready = ? OR voting_areas.ready IS NULL', true).group("candidates.id").order(
+      'LEFT JOIN "votes" ON "votes"."candidate_id" = "candidates"."id"
+         AND "votes"."voting_area_id" IN (SELECT id FROM voting_areas WHERE ready = TRUE)').group(
+      "candidates.id").order(
       'vote_sum desc')
   end
 

--- a/app/models/coalition_proportional.rb
+++ b/app/models/coalition_proportional.rb
@@ -4,7 +4,7 @@ class CoalitionProportional < ApplicationRecord
   belongs_to :result
   belongs_to :candidate
 
-  validates :result_id, :candidate_id, :number, presence: true
+  validates :result_id, :candidate_id, :number, :numerator, :denominator, presence: true
 
   # Iterate through all candidates of a coalition
   # ordered by their alliance proportional number.
@@ -30,27 +30,35 @@ class CoalitionProportional < ApplicationRecord
         .candidates
         .with_alliance_proportionals_for(result)
         .each_with_index do |candidate, index|
+        fraction = proportional_fraction(coalition_votes, index)
         create_or_update!(
           result_id: result.id,
           candidate_id: candidate.id,
-          number: calculate_proportional(coalition_votes, index)
+          number: calculate_proportional(coalition_votes, index),
+          numerator: fraction.numerator,
+          denominator: fraction.denominator
         )
       end
     end
   end
   # rubocop:enable Rails/FindEach
 
+  # Ties are groups with the same exact fraction (reduced numerator and
+  # denominator), never the rounded display number (P0.7).
   def self.find_duplicate_numbers(result_id)
-    select("coalition_proportionals.number")
+    select("coalition_proportionals.numerator, coalition_proportionals.denominator")
       .from(table_name)
       .where("coalition_proportionals.result_id = ?", result_id)
-      .group("coalition_proportionals.number having count(*) > 1")
-      .order("coalition_proportionals.number desc")
+      .group("coalition_proportionals.numerator, coalition_proportionals.denominator having count(*) > 1")
+      .order(Arel.sql("(coalition_proportionals.numerator::float8 / coalition_proportionals.denominator) desc"))
   end
 
   def self.find_draw_candidate_ids_of(draw_proportional, result_id)
     select('candidate_id')
-      .where(["number = ? AND result_id = ?", draw_proportional.number, result_id])
+      .where([
+        "numerator = ? AND denominator = ? AND result_id = ?",
+        draw_proportional.numerator, draw_proportional.denominator, result_id
+      ])
       .map(&:candidate_id)
   end
 end

--- a/db/migrate/20260707140000_add_exact_fractions_to_proportionals.rb
+++ b/db/migrate/20260707140000_add_exact_fractions_to_proportionals.rb
@@ -1,0 +1,12 @@
+class AddExactFractionsToProportionals < ActiveRecord::Migration[8.0]
+  # The float `number` (rounded to 5 decimals) stays for display and
+  # rendering compatibility; ties are detected from the exact reduced
+  # fraction so two distinct proportionals rounding to the same 5
+  # decimals can no longer create a false draw (P0.7).
+  def change
+    add_column :alliance_proportionals, :numerator, :integer
+    add_column :alliance_proportionals, :denominator, :integer
+    add_column :coalition_proportionals, :numerator, :integer
+    add_column :coalition_proportionals, :denominator, :integer
+  end
+end

--- a/db/migrate/20260707150000_tighten_schema_integrity.rb
+++ b/db/migrate/20260707150000_tighten_schema_integrity.rb
@@ -1,0 +1,36 @@
+class TightenSchemaIntegrity < ActiveRecord::Migration[8.0]
+  # The candidate import runs through psql \COPY (lib/support/psql.rb)
+  # and bypasses ActiveRecord validations entirely, so the database is
+  # the only enforcement layer. Duplicate candidate numbers would
+  # silently corrupt results (P3.3).
+  def change
+    # No FK to faculties: existing candidate data carries faculty ids
+    # without a matching faculties row (the faculty table is not part of
+    # the candidate import), so an FK would reject legitimate data.
+    add_index :candidates, :candidate_number, unique: true
+    add_index :candidates, :electoral_alliance_id
+    add_index :candidates, :faculty_id
+
+    change_column_null :candidate_results, :result_id, false
+    change_column_null :candidate_results, :candidate_id, false
+    change_column_null :alliance_results, :result_id, false
+    change_column_null :alliance_results, :electoral_alliance_id, false
+    change_column_null :coalition_results, :result_id, false
+    change_column_null :coalition_results, :electoral_coalition_id, false
+
+    # ActiveAdmin was removed years ago; this table is an orphan.
+    drop_table :active_admin_comments do |t|
+      t.integer "resource_id", null: false
+      t.string "resource_type", null: false
+      t.integer "author_id"
+      t.string "author_type"
+      t.text "body"
+      t.datetime "created_at", precision: nil
+      t.datetime "updated_at", precision: nil
+      t.string "namespace"
+      t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
+      t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
+      t.index ["resource_type", "resource_id"], name: "index_admin_notes_on_resource_type_and_resource_id"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,23 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_07_130000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_07_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
-
-  create_table "active_admin_comments", force: :cascade do |t|
-    t.integer "resource_id", null: false
-    t.string "resource_type", null: false
-    t.integer "author_id"
-    t.string "author_type"
-    t.text "body"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.string "namespace"
-    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
-    t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
-    t.index ["resource_type", "resource_id"], name: "index_admin_notes_on_resource_type_and_resource_id"
-  end
 
   create_table "admin_users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -61,12 +47,14 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_07_130000) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.float "number", null: false
+    t.integer "numerator"
+    t.integer "denominator"
     t.index ["candidate_id", "result_id"], name: "index_unique_alliance_prop_per_candidate_and_result", unique: true
   end
 
   create_table "alliance_results", force: :cascade do |t|
-    t.integer "result_id"
-    t.integer "electoral_alliance_id"
+    t.integer "result_id", null: false
+    t.integer "electoral_alliance_id", null: false
     t.integer "vote_sum_cache"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
@@ -82,8 +70,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_07_130000) do
   end
 
   create_table "candidate_results", force: :cascade do |t|
-    t.integer "result_id"
-    t.integer "candidate_id"
+    t.integer "result_id", null: false
+    t.integer "candidate_id", null: false
     t.integer "vote_sum_cache"
     t.boolean "elected", default: false, null: false
     t.datetime "created_at", precision: nil
@@ -115,6 +103,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_07_130000) do
     t.boolean "cancelled", default: false
     t.boolean "marked_invalid", default: false
     t.string "phone_number"
+    t.index ["candidate_number"], name: "index_candidates_on_candidate_number", unique: true
+    t.index ["electoral_alliance_id"], name: "index_candidates_on_electoral_alliance_id"
+    t.index ["faculty_id"], name: "index_candidates_on_faculty_id"
   end
 
   create_table "coalition_draws", force: :cascade do |t|
@@ -131,12 +122,14 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_07_130000) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.float "number", null: false
+    t.integer "numerator"
+    t.integer "denominator"
     t.index ["candidate_id", "result_id"], name: "index_unique_coalition_prop_per_candidate_and_result", unique: true
   end
 
   create_table "coalition_results", force: :cascade do |t|
-    t.integer "result_id"
-    t.integer "electoral_coalition_id"
+    t.integer "result_id", null: false
+    t.integer "electoral_coalition_id", null: false
     t.integer "vote_sum_cache"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil

--- a/lib/support/psql.rb
+++ b/lib/support/psql.rb
@@ -3,7 +3,9 @@ module Support
     def self.import_csv!(db_name:, filename:, table_name:, delimiter: ',')
       system psql(db_name, table_name, filename, delimiter), :out => File::NULL
 
-      raise RuntimeError 'Psql command failed' if $?.exitstatus.nonzero?
+      if $?.exitstatus.nonzero?
+        raise "Psql command failed (exit #{$?.exitstatus}) importing #{filename} into #{table_name}"
+      end
 
       true
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -89,24 +89,32 @@ FactoryBot.define do
 
   factory :coalition_proportional do
     number { (rand * rand(100)).to_f }
+    numerator { (number * 100_000).round }
+    denominator { 100_000 }
     result
     candidate
   end
 
   factory :alliance_proportional do
     number { (rand * rand(100)).to_f }
+    numerator { (number * 100_000).round }
+    denominator { 100_000 }
     result
     candidate
   end
 
   factory :ordered_alliance_proportional, class: AllianceProportional do
     sequence(:number) { |n| (n * 10).to_f }
+    numerator { (number * 100_000).round }
+    denominator { 100_000 }
     result
     candidate
   end
 
   factory :ordered_coalition_proportional, class: CoalitionProportional do
     sequence(:number) { |n| (n * 10).to_f }
+    numerator { (number * 100_000).round }
+    denominator { 100_000 }
     result
     candidate
   end

--- a/spec/models/candidate_vote_sums_spec.rb
+++ b/spec/models/candidate_vote_sums_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Candidate, type: :model do
+  describe ".with_vote_sums" do
+    it "keeps a candidate whose votes are all in a non-ready area, with sum 0" do
+      alliance = FactoryBot.create :electoral_alliance
+      counted = FactoryBot.create :candidate, electoral_alliance: alliance
+      uncounted = FactoryBot.create :candidate, electoral_alliance: alliance
+
+      ready_area = FactoryBot.create :voting_area, ready: true
+      pending_area = FactoryBot.create :voting_area, ready: false
+
+      FactoryBot.create :vote, candidate: counted, voting_area: ready_area, amount: 7
+      FactoryBot.create :vote, candidate: uncounted, voting_area: pending_area, amount: 5
+
+      sums = Candidate.with_vote_sums.to_a.index_by(&:id)
+
+      expect(sums.fetch(counted.id).vote_sum).to eq 7
+      expect(sums.fetch(uncounted.id).vote_sum).to eq 0
+    end
+  end
+
+  describe "AllianceProportional.calculate!" do
+    it "raises when an alliance has no coalition" do
+      result = FactoryBot.create :result
+      alliance = FactoryBot.create :electoral_alliance
+      alliance.update_column(:electoral_coalition_id, nil)
+
+      expect { AllianceProportional.calculate!(result) }
+        .to raise_error(/without a coalition/)
+    end
+  end
+end

--- a/spec/models/proportional_tie_spec.rb
+++ b/spec/models/proportional_tie_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe "Proportional tie detection", type: :model do
+  # The result must exist before the candidates: creating a Result runs
+  # calculate! which would otherwise generate proportionals for them.
+  let!(:result) { FactoryBot.create :result }
+  let!(:candidates) { Array.new(2) { FactoryBot.create :candidate } }
+
+  # 1/3 and 33333/100000 both display as 0.33333 but are not a tie.
+  it "does not report a false tie for distinct fractions rounding alike" do
+    CoalitionProportional.create!(
+      result: result, candidate: candidates[0],
+      number: 0.33333, numerator: 1, denominator: 3
+    )
+    CoalitionProportional.create!(
+      result: result, candidate: candidates[1],
+      number: 0.33333, numerator: 33333, denominator: 100_000
+    )
+
+    expect(CoalitionProportional.find_duplicate_numbers(result.id)).to be_empty
+  end
+
+  it "reports a true tie for equal fractions" do
+    candidates.each do |candidate|
+      CoalitionProportional.create!(
+        result: result, candidate: candidate,
+        number: 15.0, numerator: 15, denominator: 1
+      )
+    end
+
+    groups = CoalitionProportional.find_duplicate_numbers(result.id)
+    expect(groups.length).to eq 1
+
+    ids = CoalitionProportional.find_draw_candidate_ids_of(groups.first, result.id)
+    expect(ids.sort).to eq candidates.map(&:id).sort
+  end
+end


### PR DESCRIPTION
Implements plan items **P0.7**, **P0.8** and **P3.3** (phase 8 of the fix series). **Stacked on #36.** P0.8 was missing from the plan's suggested execution order; it belongs here since it touches the same calculation code.

## P0.7 — float proportionals can create false ties

Proportionals keep the 5-decimal display float (`number`, unchanged bit-for-bit — rendering, JSON and the certified output stay byte-identical) and additionally store the **exact reduced fraction** (`numerator`/`denominator`, new integer columns). `find_duplicate_numbers` / `find_draw_candidate_ids_of` now group by exact fraction, so two distinct proportionals differing by less than 1e-5 can no longer collapse into a false tie forcing an unnecessary draw. Chosen over converting the column to decimal: rounding at *any* fixed scale keeps the false-tie class alive, and decimal types would have rippled into JSON/spec comparisons.

The golden master passes unchanged — i.e. the certified 2009 data contains no false-tie pair, confirming this changes no historical outcome.

## P0.8 — candidates/alliances silently vanish

- The ready-area condition in `with_vote_sums`/`with_vote_sums_for` moved from WHERE into the JOIN: a candidate whose votes are all in a non-ready area now appears with sum 0 (previously dropped entirely, while zero-vote candidates correctly showed 0).
- `AllianceProportional.calculate!` raises if any alliance lacks a coalition — previously it silently got no proportionals and its candidates could never be elected. The model-level `belongs_to` requirement (#35) doesn't cover the `psql \COPY` import path, hence the calculation-time check.

## P3.3 — schema integrity

`candidates` had **zero indexes** while the import bypasses AR validations entirely: unique index on `candidate_number` (duplicates would silently corrupt results), indexes on `electoral_alliance_id` and `faculty_id`, NOT NULL on the result join table FKs, orphan `active_admin_comments` dropped. Deliberately **no** FK to faculties: candidate data legitimately carries faculty ids without faculties rows (the 2009 seed proved this immediately). Also fixes the `raise RuntimeError 'msg'` NoMethodError in `lib/support/psql.rb` that was masking the real import error.

## Verification

Full suite: **71 examples, 0 failures** — golden master byte-identical. New specs: false tie not reported / true tie reported with correct members; non-ready-area candidate kept with sum 0; orphan alliance raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)