### PR TITLE
P2.8: Remove the dead cancelled/invalid candidate concept

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -23,10 +23,7 @@ class Candidate < ApplicationRecord
   # candidates without a faculty and faculty_id is nullable in the schema.
   belongs_to :faculty, optional: true
 
-  scope :cancelled, -> { where(cancelled: true) }
   scope :without_alliance, -> { where(electoral_alliance_id: nil) }
-  scope :valid, -> { where(cancelled: false, marked_invalid: false) }
-  scope :votable, -> { where(cancelled: false, marked_invalid: false) }
   scope :by_numbering_order, -> { order("#{table_name}.numbering_order") }
 
   validates :lastname, :electoral_alliance, presence: true
@@ -47,7 +44,7 @@ class Candidate < ApplicationRecord
   # are all in a non-ready area must still appear with sum 0, exactly like a candidate
   # with no votes at all (P0.8).
   def self.with_vote_sums_for(result)
-    votable.select('candidates.id, SUM(COALESCE(votes.fixed_amount, votes.amount, 0)) as vote_sum').joins(
+    select('candidates.id, SUM(COALESCE(votes.fixed_amount, votes.amount, 0)) as vote_sum').joins(
      'LEFT JOIN  votes                 ON votes.candidate_id = candidates.id
          AND votes.voting_area_id IN (SELECT id FROM voting_areas WHERE ready = TRUE)').joins(
      'LEFT JOIN  candidate_results     ON candidate_results.candidate_id = candidates.id').where(
@@ -57,7 +54,7 @@ class Candidate < ApplicationRecord
   end
 
   def self.with_vote_sums
-    votable.select('candidates.id, SUM(COALESCE(votes.fixed_amount, votes.amount, 0)) as vote_sum').joins(
+    select('candidates.id, SUM(COALESCE(votes.fixed_amount, votes.amount, 0)) as vote_sum').joins(
       'LEFT JOIN "votes" ON "votes"."candidate_id" = "candidates"."id"
          AND "votes"."voting_area_id" IN (SELECT id FROM voting_areas WHERE ready = TRUE)').group(
       "candidates.id").order(

--- a/app/views/manage/results/_result.html.erb
+++ b/app/views/manage/results/_result.html.erb
@@ -38,7 +38,7 @@ Perusteet merkinnöille:
 <%# Vaalirenkaita yhteensä:   <%#= sprintf "%2d", coalition_count %>
 <%# Vaaliliittoja yhteensä:   <%#= sprintf "%2d", alliance_count %>
 <%# Ehdokkaita ilman liittoa: <%#= sprintf "%2d", allianceless_candidates %>
-Ehdokkaita yhteensä:      <%= sprintf "%6d", Candidate.votable.count %>
+Ehdokkaita yhteensä:      <%= sprintf "%6d", Candidate.count %>
 Valittavia ehdokkaita:    <%= sprintf "%6d", result_decorator.candidates_to_elect %>
 Äänioikeutettuja:         <%= sprintf "%6d", result_decorator.potential_voters %>
 Ääniä annettu:            <%= sprintf "%6d", result_decorator.votes_given %>

--- a/db/migrate/20260707160000_remove_cancelled_candidate_concept.rb
+++ b/db/migrate/20260707160000_remove_cancelled_candidate_concept.rb
@@ -1,0 +1,12 @@
+class RemoveCancelledCandidateConcept < ActiveRecord::Migration[8.0]
+  # Candidate cancellation happens before voting starts and lives in the
+  # ehdokastiedot repository; these flags were never set in this system.
+  # Their only runtime effect was a hazard: alliance/coalition sums
+  # included all candidates while candidate listings filtered through
+  # votable, so a flag set by accident would silently desync the
+  # proportionals from the candidate rows (P2.8).
+  def change
+    remove_column :candidates, :cancelled, :boolean, default: false
+    remove_column :candidates, :marked_invalid, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_07_150000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_07_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -100,8 +100,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_07_150000) do
     t.integer "numbering_order"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.boolean "cancelled", default: false
-    t.boolean "marked_invalid", default: false
     t.string "phone_number"
     t.index ["candidate_number"], name: "index_candidates_on_candidate_number", unique: true
     t.index ["electoral_alliance_id"], name: "index_candidates_on_electoral_alliance_id"


### PR DESCRIPTION
Implements plan item **P2.8** (phase 9 of the fix series; maintainer decision recorded 2026-07-07, resolved question Q1). **Stacked on #37.**

Candidate cancellation happens before voting starts and lives in the ehdokastiedot repository — in this system `cancelled`/`marked_invalid` were never set (the import always leaves them `false`). The concept's only runtime effect was a hazard: alliance/coalition vote sums included **all** candidates' votes while candidate listings filtered through `votable`, so a flag flipped by accident would silently make the proportionals diverge from the candidate rows.

## Changes (fix by deletion)

- Scopes `cancelled` / `valid` / `votable` deleted; `votable.` prefixes removed from `with_vote_sums_for` / `with_vote_sums`.
- Result page candidate count: `Candidate.votable.count` → `Candidate.count` (renders identically — no candidate was ever flagged).
- Migration drops `candidates.cancelled` and `candidates.marked_invalid`.
- The two columns are stripped from the 2009 seed CSV (`\COPY` maps columns positionally, so the file must match the table).

## Verification

Full suite: **71 examples, 0 failures**, golden master byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)