### PR TITLE
fix: Pull postgres CI image from public ECR Docker Hub mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:18
+        # Docker Hub mirror on AWS public ECR; avoids Docker Hub outages
+        # and anonymous-pull rate limits on shared GitHub runners.
+        image: public.ecr.aws/docker/library/postgres:18
         env:
           POSTGRES_PASSWORD: postgres
         ports:


### PR DESCRIPTION
## Why

Docker Hub intermittently fails anonymous image pulls on shared GitHub runners — [voting-api master CI run 29087579964](https://github.com/hyy-vaalit/voting-api/actions/runs/29087579964/job/86344872808) died on an HTTP 500 from Docker Hub while pulling `postgres:18` for the service container. Same fix as hyy-vaalit/voting-api#24.

## Fix

Pull the postgres service image from `public.ecr.aws/docker/library/postgres:18`, the AWS-hosted mirror of the official Docker Hub image. Same image, no Docker Hub dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)